### PR TITLE
Added the 'X-Content-Type-Options: nosniff' header.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,6 +7,8 @@ tip (unreleased)
 * ``SECURE_PROXY_SSL_HEADER`` setting now patches ``request.is_secure()`` so it
   respects proxied SSL, to avoid redirects to http that should be to https.
 
+* Added the ``X-Content-Type-Options: nosniff`` header.
+
 
 0.1.0 (2011.05.29)
 ------------------

--- a/README.rst
+++ b/README.rst
@@ -54,6 +54,9 @@ Usage
 * Set the ``SECURE_FRAME_DENY`` setting to ``True``, if you want to prevent
   framing of your pages and protect them from `clickjacking`_.
 
+* Set the ``SECURE_CONTENT_TYPE_NOSNIFF`` setting to ``True``, if you want to prevent
+  the browser from guessing asset content types.
+
 * Set ``SESSION_COOKIE_SECURE`` and ``SESSION_COOKIE_HTTPONLY`` to ``True`` if
   you are using ``django.contrib.sessions``. These settings are not part of
   ``django-secure``, but they should be used if running a secure site, and the

--- a/djangosecure/check/djangosecure.py
+++ b/djangosecure/check/djangosecure.py
@@ -49,6 +49,21 @@ check_frame_deny.messages = {
     }
 
 
+@boolean_check("CONTENT_TYPE_NOSNIFF_NOT_ENABLED")
+def check_content_type_nosniff():
+    return conf.SECURE_CONTENT_TYPE_NOSNIFF
+
+check_content_type_nosniff.messages = {
+    "CONTENT_TYPE_NOSNIFF_NOT_ENABLED": (
+        "Your SECURE_CONTENT_TYPE_NOSNIFF setting is not set to True, "
+        "so your pages will not be served with an "
+        "'x-content-type-options: nosniff' header. "
+        "You should consider enabling this header to prevent the "
+        "browser from identifying content types incorrectly."
+        )
+    }
+
+
 @boolean_check("SSL_REDIRECT_NOT_ENABLED")
 def check_ssl_redirect():
     return conf.SECURE_SSL_REDIRECT

--- a/djangosecure/conf.py
+++ b/djangosecure/conf.py
@@ -20,6 +20,7 @@ class Configuration(object):
 conf = Configuration(
     SECURE_HSTS_SECONDS=0,
     SECURE_FRAME_DENY=False,
+    SECURE_CONTENT_TYPE_NOSNIFF=False,
     SECURE_SSL_REDIRECT=False,
     SECURE_SSL_HOST=None,
     SECURE_REDIRECT_EXEMPT=[],
@@ -31,6 +32,7 @@ conf = Configuration(
         "djangosecure.check.djangosecure.check_security_middleware",
         "djangosecure.check.djangosecure.check_sts",
         "djangosecure.check.djangosecure.check_frame_deny",
+        "djangosecure.check.djangosecure.check_content_type_nosniff",
         "djangosecure.check.djangosecure.check_ssl_redirect",
         ]
     )

--- a/djangosecure/middleware.py
+++ b/djangosecure/middleware.py
@@ -9,6 +9,7 @@ class SecurityMiddleware(object):
     def __init__(self):
         self.sts_seconds = conf.SECURE_HSTS_SECONDS
         self.frame_deny = conf.SECURE_FRAME_DENY
+        self.content_type_nosniff = conf.SECURE_CONTENT_TYPE_NOSNIFF
         self.redirect = conf.SECURE_SSL_REDIRECT
         self.redirect_host = conf.SECURE_SSL_HOST
         self.proxy_ssl_header = conf.SECURE_PROXY_SSL_HEADER
@@ -44,4 +45,8 @@ class SecurityMiddleware(object):
                 not 'strict-transport-security' in response):
             response["strict-transport-security"] = ("max-age=%s"
                                                      % self.sts_seconds)
+        if (self.content_type_nosniff and
+                not 'x-content-type-options' in response):
+            response["x-content-type-options"] = "nosniff"
+
         return response

--- a/doc/checksecure.rst
+++ b/doc/checksecure.rst
@@ -47,6 +47,10 @@ default:
 
    Warns if :ref:`SECURE_FRAME_DENY` is not ``True``.
 
+.. py:function:: check_content_type_nosniff
+
+   Warns if :ref:`SECURE_CONTENT_TYPE_NOSNIFF` is not ``True``.
+
 .. py:function:: check_ssl_redirect
 
    Warns if :ref:`SECURE_SSL_REDIRECT` is not ``True``.

--- a/doc/middleware.rst
+++ b/doc/middleware.rst
@@ -70,6 +70,31 @@ you set the :ref:`SECURE_HSTS_SECONDS` setting to a nonzero integer value.
 
 .. _"Strict-Transport-Security" header: http://en.wikipedia.org/wiki/Strict_Transport_Security
 
+.. _x-content-type-options:
+
+X-Content-Type-Options: nosniff
+-------------------------------
+
+Some browsers will try to guess the content types of the assets that they
+fetch, overriding the ``Content-Type`` header. While this can help display
+sites with improperly configured servers, it can also pose as a security
+concern.
+
+If your site serves user uploaded files, a malicious user could upload a
+specially crafted file that would be interpreted as HTML or Javascript by
+the browser when you where expected it to be something harmless.
+
+To learn more about this header and how the browser treats it, you can
+read about it on the `IE Security Blog`_.
+
+To prevent the browser from guessing the content type, and always using
+the type provided in the ``Content-Type`` header, you can pass the
+``X-Content-Type-Options: nosniff`` header. This is what the
+``SecurityMiddleware`` will do for all responses if the
+:ref:`SECURE_CONTENT_TYPE_NOSNIFF` setting is ``True``.
+
+.. _IE Security Blog: http://blogs.msdn.com/b/ie/archive/2008/09/02/ie8-security-part-vi-beta-2-update.aspx
+
 .. _ssl-redirect:
 
 SSL Redirect

--- a/doc/settings.rst
+++ b/doc/settings.rst
@@ -21,6 +21,7 @@ Defaults to::
         "djangosecure.check.djangosecure.check_security_middleware",
         "djangosecure.check.djangosecure.check_sts",
         "djangosecure.check.djangosecure.check_frame_deny",
+        "djangosecure.check.djangosecure.check_content_type_nosniff",
         "djangosecure.check.djangosecure.check_ssl_redirect",
     ]
 
@@ -45,6 +46,17 @@ If set to a non-zero integer value, causes :doc:`middleware` to set the
 already have that header.
 
 Defaults to ``0``.
+
+.. _SECURE_CONTENT_TYPE_NOSNIFF:
+
+SECURE_CONTENT_TYPE_NOSNIFF
+---------------------------
+
+If set to ``True``, causes :doc:`middleware` to set the
+:ref:`x-content-type-options` header on all responses that do not already
+have that header.
+
+Defaults to ``False``.
 
 .. _SECURE_PROXY_SSL_HEADER:
 


### PR DESCRIPTION
The middleware can now add the 'X-Content-Type-Options: nosniff' header to responses.

I have tested this in my own projects and I have also run all the Tox tests.
